### PR TITLE
build-vm-image.sh: replace virt-install by direct QEMU call

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,13 @@ sudo dnf builddep https://src.fedoraproject.org/rpms/edk2/raw/f41/f/edk2.spec
 sudo dnf install cargo rust rust-std-static-x86_64-unknown-none \
                  autoconf automake autoconf-archive \
                  buildah podman cbindgen bindgen-cli CUnit-devel openssl \
-                 sqlite-devel virt-install ncat awk script xxd
+                 sqlite-devel ncat awk script xxd virt-install
 ```
+For automatic setup of the guest image, virt-install is used in a following step.
+This requires a running instance of libvirt, which will be installed by the `dnf` command
+above. Alternatively, a standalone instance of QEMU can be used as well. In this case
+the installation of libvirt and `virt-install` can be skipped and the `mtools` package
+is required instead.
 
 ## Build all components
 
@@ -83,6 +88,9 @@ to unseal the LUKS key.
 # Or you can specify your
 ./build-vm-image.sh --passphrase <custom LUKS passphrase>
 ```
+By default `virt-install` (requiring a running instance of libvirt) is used for automatic guest image installation.
+To attempt an installation without libvirt and using the QEMU binary built in the previous step directly,
+add the `--no-libvirt` option to the commands above. This can be useful in containerized environments, for example.
 
 ## Start Key Broker Service (KBS)
 

--- a/build-vm-image.sh
+++ b/build-vm-image.sh
@@ -55,6 +55,7 @@ clearpart --all --initlabel --disklabel=gpt --drives=vda
 part /boot/efi --size=512 --fstype=efi
 part /boot --size=512 --fstype=xfs --label=boot
 part / --fstype="xfs" --ondisk=vda --encrypted --label=root --luks-version=luks2 --grow --passphrase "${CVM_LUKS_PASSPHRASE}"
+bootloader --append="console=ttyS0"
 
 %packages
 @^server-product-environment

--- a/vm.conf
+++ b/vm.conf
@@ -3,12 +3,16 @@
 SCRIPT_PATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 
 QEMU="${SCRIPT_PATH}/qemu/build/qemu-system-x86_64"
+QEMU_IMG="${SCRIPT_PATH}/qemu/build/qemu-img"
 QEMU_MONITOR_PORT="56017"
 
 # CVM parameters
 CVM_IMAGE="${SCRIPT_PATH}/images/fedora-luks.qcow2"
 CVM_LUKS_PASSPHRASE="MY-LUKS-PASSPHRASE"
 CVM_FEDORA="41"
+
+# Guest image configuration
+INSTALLER_URL="https://dl.fedoraproject.org/pub/fedora/linux/releases/${CVM_FEDORA}/Server/x86_64/os/"
 
 # SVSM proxy configuration
 PROXY_SOCK="${SCRIPT_PATH}/svsm-proxy.sock"


### PR DESCRIPTION
Use a direct call of QEMU to run the Fedora installer instead of relying
on virt-install and thus requiring the libvirtd to be installed and
running.

This allows running the script inside a podman container.

