### PR TITLE
Use Fedora 42 guest + rawhide kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,7 +565,7 @@ boot (bypassing the GRUB bootloader) and reboot the VM (in non-confidential
 mode) to complete the installation (the reboot is required).
 
 ```shell
-dnf install -y uki-direct kernel-uki-virt
+dnf --enablerepo=rawhide install --assumeyes uki-direct kernel-uki-virt
 # reboot into the new kernel
 reboot
 ```

--- a/build-vm-image.sh
+++ b/build-vm-image.sh
@@ -77,8 +77,11 @@ dnf install -y tpm2-tools
 cat /etc/crypttab | awk '{print \$1" "\$2" - tpm2-device=auto,tpm2-pcrs=0,1,4,5,7,9"}' | tee /etc/crypttab
 # Put "tpm" driver in the initrd
 echo 'add_drivers+=" tpm "' > /etc/dracut.conf.d/99-tpm.conf
-# Trigger initrd rebuild
+# Trigger initrd rebuild (for the stock kernel)
 dracut --regenerate-all --force
+# Install newer kernel from rawhide
+dnf --assumeyes install fedora-repos-rawhide
+dnf --assumeyes --enablerepo=rawhide upgrade kernel
 %end
 EOF
 

--- a/vm.conf
+++ b/vm.conf
@@ -9,11 +9,10 @@ QEMU_MONITOR_PORT="56017"
 # CVM parameters
 CVM_IMAGE="${SCRIPT_PATH}/images/fedora-luks.qcow2"
 CVM_LUKS_PASSPHRASE="MY-LUKS-PASSPHRASE"
-CVM_FEDORA="rawhide"
+CVM_FEDORA="42"
 
 # Guest image configuration
-#INSTALLER_URL="https://kojipkgs.fedoraproject.org/compose/rawhide/latest-Fedora-Rawhide/compose/Server/x86_64/os/"
-INSTALLER_URL="https://kojipkgs.fedoraproject.org/compose/rawhide/Fedora-Rawhide-20250810.n.0/compose/Server/x86_64/os/"
+INSTALLER_URL="https://dl.fedoraproject.org/pub/fedora/linux/releases/${CVM_FEDORA}/Server/x86_64/os/"
 
 # SVSM proxy configuration
 PROXY_SOCK="${SCRIPT_PATH}/svsm-proxy.sock"


### PR DESCRIPTION
Switch back to Fedora 42 as the guest OS, but install the kernel from
rawhide (Linux 6.17)
